### PR TITLE
Block right clicks on unmasked cells

### DIFF
--- a/game.js
+++ b/game.js
@@ -62,6 +62,8 @@ Game.prototype.bindEvents = function () {
     })
 
     target.addEventListener('contextmenu', function (evt) {
+      evt.preventDefault()
+      if (!target.isMasked) { return; }
       if (target.isFlagged) {
         target.innerHTML = that.twemoji ? twemoji.parse(that.emojiset[3]) : that.emojiset[3]
         target.isFlagged = false
@@ -69,7 +71,6 @@ Game.prototype.bindEvents = function () {
         target.innerHTML = that.twemoji ? twemoji.parse(that.emojiset[2]) : that.emojiset[2]
         target.isFlagged = true
       }
-      evt.preventDefault()
     })
   })
 }


### PR DESCRIPTION
There was a minor issue:
1. Find a number cell.
2. Right click on it. It becomes a bomb flag.
3. Right click again.
4. Left click. You cannot make the cell a number again. :bug: 

I added an additional check to block right clicks on unmasked cells. :four_leaf_clover: 
